### PR TITLE
Fix TrackingService::parseResponse when status code doesnt exist

### DIFF
--- a/Service/TrackingService.php
+++ b/Service/TrackingService.php
@@ -51,7 +51,7 @@ class TrackingService extends AbstractService
         $body = $responses[0]['body'];
         $status = $body['status'][0];
         if ($status['code'] !== "0") {
-            throw new TrackingRequestException($status['message'], $status['code']);
+            throw new TrackingRequestException($status['message'], $status['code'] ?? 0);
         }
 
         $parcel = $body['parcel'];


### PR DESCRIPTION
Yep, on a pas mal de warning sur sentry dû au fait qu'on controle pas la clef `statut` de la réponse colissimo